### PR TITLE
Support dynamic parameters to the authorize URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install omniauth_openid_connect
-    
+
 ## Supported Ruby Versions
 
 OmniAuth::OpenIDConnect is tested under 2.4, 2.5, 2.6, 2.7
@@ -61,6 +61,8 @@ config.omniauth :openid_connect, {
 | send_scope_to_token_endpoint | Should the scope parameter be sent to the authorization token endpoint?                                                                                       | no       | true                       | one of: true, false                                 |
 | post_logout_redirect_uri     | The logout redirect uri to use per the [session management draft](https://openid.net/specs/openid-connect-session-1_0.html)                                   | no       | empty                      | https://myapp.com/logout/callback                   |
 | uid_field                    | The field of the user info response to be used as a unique id                                                                                                 | no       | 'sub'                      | "sub", "preferred_username"                         |
+| extra_authorize_params       | A hash of extra fixed parameters that will be merged to the authorization request                                                                             | no       | Hash                       | {"tenant" => "common"}                              |
+| allow_authorize_params       | A list of allowed dynamic parameters that will be merged to the authorization request                                                                         | no       | Array                      | [:screen_name]                                      |
 | client_options               | A hash of client options detailed in its own section                                                                                                          | yes      |                            |                                                     |
 
 ### Client Config Options

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -55,6 +55,7 @@ module OmniAuth
       option :client_auth_method
       option :post_logout_redirect_uri
       option :extra_authorize_params, {}
+      option :allow_authorize_params, []
       option :uid_field, 'sub'
 
       def uid
@@ -172,6 +173,10 @@ module OmniAuth
         }
 
         opts.merge!(options.extra_authorize_params) unless options.extra_authorize_params.empty?
+
+        options.allow_authorize_params.each do |key|
+          opts[key] = request.params[key.to_s] unless opts.key?(key)
+        end
 
         client.authorization_uri(opts.reject { |_k, v| v.nil? })
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -150,6 +150,19 @@ module OmniAuth
         assert(strategy.authorize_uri =~ /resource=xyz/, 'URI must contain custom params')
       end
 
+      def test_request_phase_with_allowed_params
+        strategy.options.issuer = 'example.com'
+        strategy.options.allow_authorize_params = [:name, :logo, :resource]
+        strategy.options.extra_authorize_params = {resource: 'xyz'}
+        strategy.options.client_options.host = 'example.com'
+        request.stubs(:params).returns('name' => 'example', 'logo' => 'example_logo', 'resource' => 'abc', 'not_allowed' => 'filter_me')
+
+        assert(strategy.authorize_uri =~ /resource=xyz/, 'URI must contain fixed param resource')
+        assert(strategy.authorize_uri =~ /name=example/, 'URI must contain dynamic param name')
+        assert(strategy.authorize_uri =~ /logo=example_logo/, 'URI must contain dynamic param logo')
+        refute(strategy.authorize_uri =~ /not_allowed=filter_me/, 'URI must filter not allowed param')
+      end
+
       def test_uid
         assert_equal user_info.sub, strategy.uid
 


### PR DESCRIPTION
This PR is pretty similar to https://github.com/m0n9oose/omniauth_openid_connect/pull/50
It provides the possibility to add custom parameters dynamically to the authorize uri.