### PR TITLE
Upgrade Faker and replace Travis with Github Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,31 @@
+name: Main
+on:
+  push:
+    branches:
+      - main
+      - master
+
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  base:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby: ["2.5", "2.6", "2.7", "3.0"]
+    name: Ruby ${{ matrix.ruby }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: ruby
-rvm:
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
-  - jruby-head
-  - ruby-head

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Originally was [omniauth-openid-connect](https://github.com/jjbohn/omniauth-open
 
 I've forked this repository and launch as separate gem because maintaining of original was dropped.
 
-[![Build Status](https://travis-ci.org/m0n9oose/omniauth_openid_connect.png?branch=master)](https://travis-ci.org/m0n9oose/omniauth_openid_connect)
+[![Build Status](https://github.com/omniauth/omniauth_openid_connect/actions/workflows/main.yml/badge.svg)](https://github.com/omniauth/omniauth_openid_connect/actions/workflows/main.yml)
 
 ## Installation
 
@@ -28,7 +28,7 @@ And then execute:
 Or install it yourself as:
 
     $ gem install omniauth_openid_connect
-    
+
 ## Supported Ruby Versions
 
 OmniAuth::OpenIDConnect is tested under 2.4, 2.5, 2.6, 2.7

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'omniauth', '>= 1.9', '< 3'
   spec.add_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'coveralls', '~> 0.8'
-  spec.add_development_dependency 'faker', '~> 1.6'
+  spec.add_development_dependency 'faker', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.2'
   spec.add_development_dependency 'guard-minitest', '~> 2.4'


### PR DESCRIPTION
- Upgrade faker to allow tests to run locally
- Replace Travis with Github Actions

Running on my own PR https://github.com/davidwessman/omniauth_openid_connect/pull/1

Could not get the tests to run for Ruby 3.1, missing `net/smtp`.