### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0"]
+        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1"]
     name: Ruby ${{ matrix.ruby }}
 
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,9 @@
 
 source 'https://rubygems.org'
 gemspec
+
+if Gem::Version.new(RUBY_VERSION.dup) >= Gem::Version.new('3.1')
+  gem 'net-imap', require: false
+  gem 'net-pop', require: false
+  gem 'net-smtp', require: false
+end

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Supported Ruby Versions
 
-OmniAuth::OpenIDConnect is tested under 2.4, 2.5, 2.6, 2.7
+OmniAuth::OpenIDConnect is tested under 2.5, 2.6, 2.7, 3.0, 3.1
 
 ## Usage
 


### PR DESCRIPTION
In addition to updating the CI configuration I had to include the net-(imap|pop|smtp) gems for Ruby 3.1+ to get everything green.