### PR TITLE
When calling access_token! make the first argument client_auth_method

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -221,8 +221,8 @@ module OmniAuth
         return @access_token if @access_token
 
         @access_token = client.access_token!(
-          scope: (options.scope if options.send_scope_to_token_endpoint),
-          client_auth_method: options.client_auth_method
+          client_auth_method: options.client_auth_method,
+          scope: (options.scope if options.send_scope_to_token_endpoint)
         )
 
         verify_id_token!(@access_token.id_token) if configured_response_type == 'code'


### PR DESCRIPTION
it could be problematic that on `Rack::Oauth2::Client` when it tries to set the `client_auth_method` https://github.com/nov/rack-oauth2/blob/9cb51cee480d00a7df45e8b940ac8ad20721d6a7/lib/rack/oauth2/client.rb#L137

It will always take the first argument as the default `client_auth_method`. Right now when calling `access_token!` on the client the first argument sent is `scope` instead of `client_auth_method`.