### PR TITLE
use jwks caching feature of openid_connect gem

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -181,10 +181,12 @@ module OmniAuth
         client.authorization_uri(opts.reject { |_k, v| v.nil? })
       end
 
-      def public_key
-        return config.jwks if options.discovery
-
-        key_or_secret || config.jwks
+      def public_key_or_config
+        if options.discovery || key_or_secret.blank?
+          config
+        else
+          key_or_secret
+        end
       end
 
       private
@@ -231,7 +233,7 @@ module OmniAuth
       end
 
       def decode_id_token(id_token)
-        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, public_key)
+        ::OpenIDConnect::ResponseObject::IdToken.decode(id_token, public_key_or_config)
       end
 
       def client_options

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'omniauth', '>= 1.9', '< 3'
-  spec.add_dependency 'openid_connect', '~> 1.1'
+  spec.add_dependency 'openid_connect', '~> 1.4'
   spec.add_development_dependency 'faker', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.2'


### PR DESCRIPTION
`OpenIDConnect::ResponseObject::IdToken.decode` now accepts `OpenIDConnect::Discovery::Provider::Config::Response` instead of `key`.
https://github.com/nov/openid_connect/blob/master/spec/openid_connect/response_object/id_token_spec.rb#L254-L300

then fetch JWK specified by the ID Token `kid` header from `jwks_uri` using `JSON::JWK::Set::Fetcher`.
https://github.com/nov/openid_connect/blob/master/lib/openid_connect/response_object/id_token.rb#L70-L73
https://github.com/nov/openid_connect/blob/master/lib/openid_connect/discovery/provider/config/response.rb#L90-L93

and `JSON::JWK::Set::Fetcher` has JWKS caching feature.
https://github.com/nov/json-jwt/wiki/JWK-Set#fetching

so, once `omniauth_openid_connect` gem users specify `JSON::JWK::Set::Fetcher.cache = Rails.cache`, this gem start caching JWKS by `kid`.