### PR TITLE
addressable gem removed from dependencies

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'addressable/uri'
 require 'timeout'
 require 'net/http'
 require 'open-uri'

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |spec|
     'rubygems_mfa_required' => 'true',
   }
 
-  spec.add_dependency 'addressable', '~> 2.5'
   spec.add_dependency 'omniauth', '>= 1.9', '< 3'
   spec.add_dependency 'openid_connect', '~> 1.1'
   spec.add_development_dependency 'faker', '~> 2.0'


### PR DESCRIPTION
`addressable` gem looks like it hasn't been used for a long time.

In my project, this dependency is making it difficult to update.