### PR TITLE
Support the "nonce" parameter forwarding without a session

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,10 +119,10 @@ These are the configuration options for the client_options hash of the configura
   property can be used to add the attribute to the token request. Initial value is `true`, which means that the
   scope attribute is included by default.
 
-### Additional notes
+## Additional notes
   * In some cases, you may want to go straight to the callback phase - e.g. when requested by a stateless client, like a mobile app.
   In such example, the session is empty, so you have to forward certain parameters received from the client.
-  Currently supported one is `code_verifier` - simply provide it as the `/callback` request parameter.
+  Currently supported ones are `code_verifier` and `nonce` - simply provide them as the `/callback` request parameters.
 
 For the full low down on OpenID Connect, please check out
 [the spec](http://openid.net/specs/openid-connect-core-1_0.html).

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -378,7 +378,7 @@ module OmniAuth
 
         decode_id_token(id_token).verify!(issuer: options.issuer,
                                           client_id: client_options.identifier,
-                                          nonce: stored_nonce)
+                                          nonce: params['nonce'].presence || stored_nonce)
       end
 
       class CallbackError < StandardError


### PR DESCRIPTION
I'll rebase the README with the updates from https://github.com/omniauth/omniauth_openid_connect/pull/128 as soon as that gets the necessary second review.