### PR TITLE
Add email_verified claim in user info

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -74,6 +74,7 @@ module OmniAuth
         {
           name: user_info.name,
           email: user_info.email,
+          email_verified: user_info.email_verified,
           nickname: user_info.preferred_username,
           first_name: user_info.given_name,
           last_name: user_info.family_name,

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -429,6 +429,7 @@ module OmniAuth
         info = strategy.info
         assert_equal user_info.name, info[:name]
         assert_equal user_info.email, info[:email]
+        assert_equal user_info.email_verified, info[:email_verified]
         assert_equal user_info.preferred_username, info[:nickname]
         assert_equal user_info.given_name, info[:first_name]
         assert_equal user_info.family_name, info[:last_name]

--- a/test/strategy_test_case.rb
+++ b/test/strategy_test_case.rb
@@ -21,6 +21,7 @@ class StrategyTestCase < MiniTest::Test
       sub: SecureRandom.hex(16),
       name: Faker::Name.name,
       email: Faker::Internet.email,
+      email_verified: Faker::Boolean.boolean,
       nickname: Faker::Name.first_name,
       preferred_username: Faker::Internet.user_name,
       given_name: Faker::Name.first_name,


### PR DESCRIPTION
This boolean field is a standard OpenID claim:
https://openid.net/specs/openid-connect-core-1_0.html#StandardClaims

This is part of the effort to upstream changes in the GitLab fork: https://gitlab.com/gitlab-org/ruby/gems/gitlab-omniauth-openid-connect/-/issues/5.