### PR TITLE
Add logout_path option to permit various logout paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ config.omniauth :openid_connect, {
 | pkce_options                 | Specify a custom implementation of the PKCE code challenge/method.                                                                                            | no       | SHA256(code_challenge) in hex | Proc to customise the code challenge generation     |
 | client_options               | A hash of client options detailed in its own section                                                                                                          | yes      |                               |                                                     |
 | jwt_secret_base64 | For HMAC with SHA2 (e.g. HS256) signing algorithms, specify the base64-encoded secret used to sign the JWT token. Defaults to the OAuth2 client secret if not specified. | no | client_options.secret | "bXlzZWNyZXQ=\n"
+| logout_path | The log out is only triggered when the request path ends on this path | no | '/logout' | '/sign_out'
 
 ### Client Config Options
 

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -434,7 +434,7 @@ module OmniAuth
       end
 
       def logout_path_pattern
-        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}#{logout_path}}
+        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}#{options.logout_path}}
       end
 
       def id_token_callback_phase

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -434,7 +434,7 @@ module OmniAuth
       end
 
       def logout_path_pattern
-        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}#{options.logout_path}}
+        @logout_path_pattern ||= /\A#{Regexp.quote(request_path)}#{options.logout_path}/
       end
 
       def id_token_callback_phase

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -68,6 +68,8 @@ module OmniAuth
         code_challenge_method: 'S256',
       }
 
+      option :logout_path, '/logout'
+
       def uid
         user_info.raw_attributes[options.uid_field.to_sym] || user_info.sub
       end
@@ -432,7 +434,7 @@ module OmniAuth
       end
 
       def logout_path_pattern
-        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}(/logout)}
+        @logout_path_pattern ||= %r{\A#{Regexp.quote(request_path)}#{logout_path}}
       end
 
       def id_token_callback_phase

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -69,6 +69,17 @@ module OmniAuth
         strategy.other_phase
       end
 
+      def test_logout_phase_with_logout_path
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.logout_path = '/sign_out'
+
+        request.stubs(:path).returns('/auth/openid_connect/sign_out')
+
+        strategy.expects(:call_app!)
+        strategy.other_phase
+      end
+
       def test_logout_phase
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'


### PR DESCRIPTION
Currently this gem only  redirects to the `end_session_uri` if the current path matches a `logout_path_pattern` ending in `/logout`.

This `/logout` is a constant string in the source code and cannot be changed through options. 

As there are applications (e.g. Mastodon) that use a different path ending for their logout path (e.g. /auth/sign_out), I believe that an option should be added (defaulting to `/logout`) to supply a different ending and allowing these applications to use OmniAuth OpenID Connect with logout enabled.

