### PR TITLE
Fix uninitialized constant error

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -340,7 +340,7 @@ module OmniAuth
         keyset.each do |key|
           begin
             decoded = decode!(id_token, key)
-          rescue JSON::JWS::VerificationFailed, JSON::JWS::UnexpectedAlgorithm, JSON::JWS::UnknownAlgorithm
+          rescue JSON::JWS::VerificationFailed, JSON::JWS::UnexpectedAlgorithm, JSON::JWK::UnknownAlgorithm
             next
           end
 


### PR DESCRIPTION
When decoding a JWT with some error, we need to catch the right error:
    
`JSON::JWS::UnknownAlgorithm` => `JSON::JWK::UnknownAlgorithm`

Relates to https://github.com/omniauth/omniauth_openid_connect/issues/146