### PR TITLE
Update openid_connect to 2.2

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -228,7 +228,7 @@ module OmniAuth
       private
 
       def fetch_key
-        @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get_content(client_options.jwks_uri))
+        @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get(client_options.jwks_uri).body)
       end
 
       def base64_decoded_jwt_secret

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   }
 
   spec.add_dependency 'omniauth', '>= 1.9', '< 3'
-  spec.add_dependency 'openid_connect', '~> 1.1'
+  spec.add_dependency 'openid_connect', '~> 2.2'
   spec.add_development_dependency 'faker', '~> 2.0'
   spec.add_development_dependency 'guard', '~> 2.14'
   spec.add_development_dependency 'guard-bundler', '~> 2.2'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -520,10 +520,14 @@ module OmniAuth
         strategy.options.client_options.jwks_uri = 'https://jwks.example.com'
         strategy.options.response_type = 'id_token'
 
-        HTTPClient
-          .any_instance.stubs(:get_content)
-          .with(strategy.options.client_options.jwks_uri)
-          .returns(jwks.to_json)
+        ::OpenIDConnect.stubs(:http_client)
+                       .returns(
+                         Faraday.new do |builder|
+                           builder.adapter :test do |stubs|
+                             stubs.get(strategy.options.client_options.jwks_uri) { [200, {}, jwks.to_json] }
+                           end
+                         end
+                       )
 
         strategy.unstub(:user_info)
         access_token = stub('OpenIDConnect::AccessToken')
@@ -799,8 +803,7 @@ module OmniAuth
           access_token: 'test_access_token',
           id_token: jwt.to_s,
           token_type: 'Bearer',
-        }.to_json
-        success = Struct.new(:status, :body).new(200, json_response)
+        }
 
         request.stubs(:path).returns('')
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
@@ -809,11 +812,19 @@ module OmniAuth
         id_token.stubs(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, nonce: nonce).returns(true)
         ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
 
-        HTTPClient.any_instance.stubs(:post).with(
-          "#{ opts.scheme }://#{ opts.host }:#{ opts.port }#{ opts.token_endpoint }",
-          { scope: 'openid', grant_type: :client_credentials, client_id: @identifier, client_secret: @secret },
-          {}
-        ).returns(success)
+        ::Rack::OAuth2.stubs(:http_client)
+                      .returns(
+                        Faraday.new do |builder|
+                          builder.adapter :test do |stubs|
+                            stubs.post(
+                              "#{ opts.scheme }://#{ opts.host }:#{ opts.port }#{ opts.token_endpoint }",
+                              { scope: 'openid', grant_type: :client_credentials, client_id: @identifier, client_secret: @secret }
+                            ) do
+                              [200, {}, json_response]
+                            end
+                          end
+                        end
+                      )
 
         assert(strategy.send(:access_token))
       end


### PR DESCRIPTION
I am trying to use omniauth_openid_connect in a service using the apple_id gem.
However, it seems that the version of openid_connect that omniauth_openid_connect depends on is outdated, making it impossible to install with the version of the apple_id gem we are using. 
So, I would like to make omniauth_openid_connect compatible with the newer version of openid_connect.

* Note that the openid_connect gem changed from HTTPClient to Faraday in version 2.x, so some modifications will be necessary. But the dependency is small (used only in `fetch_key` method and tests), so I believe the required changes will be minimal.
