### PR TITLE
Drop Ruby 2.5 and 2.6 CI support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.5", "2.6", "2.7", "3.0", "3.1", "3.2"]
+        ruby: ["2.7", "3.0", "3.1", "3.2"]
     name: Ruby ${{ matrix.ruby }}
 
     steps:


### PR DESCRIPTION
These versions reached end-of-life last year, so let's drop support.