### PR TITLE
Fix handling of JWKS response

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -404,7 +404,7 @@ module OmniAuth
       end
 
       def parse_jwk_key(key)
-        json = JSON.parse(key)
+        json = key.is_a?(String) ? JSON.parse(key) : key
         return JSON::JWK::Set.new(json['keys']) if json.key?('keys')
 
         JSON::JWK.new(json)

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -39,4 +39,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 1.12'
   spec.add_development_dependency 'simplecov', '~> 0.21'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.8'
+  spec.add_development_dependency 'webmock', '~> 3.18'
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require 'minitest/autorun'
 require 'mocha/minitest'
 require 'faker'
 require 'active_support'
+require 'webmock/minitest'
 
 SimpleCov.start do
   if ENV['CI']


### PR DESCRIPTION
This fixes a regression in v0.7.0 where the JWKS response returns as a
Hash instead of a String due to the change in openid_connect modifying
the Faraday response handling.

This commit also improves the testing by using webmock instead of
stubbing the Farday response.

Closes #156