### PR TITLE
Add `parse_jwk_key_from_hash` to handle jwks Hash

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -228,7 +228,7 @@ module OmniAuth
       private
 
       def fetch_key
-        @fetch_key ||= parse_jwk_key(::OpenIDConnect.http_client.get(client_options.jwks_uri).body)
+        @fetch_key ||= parse_jwk_key_from_hash(::OpenIDConnect.http_client.get(client_options.jwks_uri).body)
       end
 
       def base64_decoded_jwt_secret
@@ -404,7 +404,10 @@ module OmniAuth
       end
 
       def parse_jwk_key(key)
-        json = JSON.parse(key)
+        parse_jwk_key_from_hash(JSON.parse(key))
+      end
+
+      def parse_jwk_key_from_hash(json)
         return JSON::JWK::Set.new(json['keys']) if json.key?('keys')
 
         JSON::JWK.new(json)

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -524,7 +524,7 @@ module OmniAuth
                        .returns(
                          Faraday.new do |builder|
                            builder.adapter :test do |stubs|
-                             stubs.get(strategy.options.client_options.jwks_uri) { [200, {}, jwks.to_json] }
+                             stubs.get(strategy.options.client_options.jwks_uri) { [200, {}, JSON.parse(JSON.generate(jwks))] }
                            end
                          end
                        )


### PR DESCRIPTION
Fix #156 

`parse_jwk_key_from_hash()` has been added to handle the Hash returned by `::OpenIDConnect.http_client.get(client_options.jwks_uri).body`.
The implementation of `parse_jwk_key()` has also been updated to use `parse_jwk_key_from_hash()`.
