### PR TITLE
Add RP initiated logout with `id_token_hint` request parameter

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -423,9 +423,17 @@ module OmniAuth
       def encoded_post_logout_redirect_uri
         return unless options.post_logout_redirect_uri
 
-        URI.encode_www_form(
-          post_logout_redirect_uri: options.post_logout_redirect_uri
-        )
+        logout_uri_params = {
+          'post_logout_redirect_uri' => options.post_logout_redirect_uri,
+        }
+
+        unless query_string.empty?
+          token_key = 'id_token_hint'
+          query_params = CGI.parse(query_string[1..])
+          logout_uri_params[token_key] = query_params[token_key].first if query_params.key?(token_key)
+        end
+
+        URI.encode_www_form(logout_uri_params)
       end
 
       def end_session_endpoint_is_valid?

--- a/omniauth_openid_connect.gemspec
+++ b/omniauth_openid_connect.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'guard-bundler', '~> 2.2'
   spec.add_development_dependency 'guard-minitest', '~> 2.4'
   spec.add_development_dependency 'minitest', '~> 5.1'
-  spec.add_development_dependency 'mocha', '~> 1.7'
+  spec.add_development_dependency 'mocha', '~> 2.1.0'
   spec.add_development_dependency 'rake', '~> 12.0'
   spec.add_development_dependency 'rubocop', '~> 1.12'
   spec.add_development_dependency 'simplecov', '~> 0.21'

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -54,7 +54,7 @@ module OmniAuth
         issuer.stubs(:issuer).returns('https://example.com/')
         ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(issuer)
 
-        config = stub('OpenIDConnect::Discovery::Provder::Config')
+        config = stub('OpenIDConnect::Discovery::Provider::Config')
         config.stubs(:authorization_endpoint).returns('https://example.com/authorization')
         config.stubs(:token_endpoint).returns('https://example.com/token')
         config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
@@ -64,6 +64,33 @@ module OmniAuth
 
         request.stubs(:path_info).returns('/auth/openid_connect/logout')
         request.stubs(:path).returns('/auth/openid_connect/logout')
+        request.stubs(:query_string).returns('')
+
+        strategy.expects(:redirect).with(expected_redirect)
+        strategy.other_phase
+      end
+
+      def test_logout_phase_with_discovery_and_post_logout_redirect_uri_and_id_token_hint
+        expected_redirect = 'https://example.com/logout?post_logout_redirect_uri=https%3A%2F%2Fmysite.com&id_token_hint=abcd1234'
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.discovery = true
+        strategy.options.post_logout_redirect_uri = 'https://mysite.com'
+
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('https://example.com/')
+        ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(issuer)
+
+        config = stub('OpenIDConnect::Discovery::Provider::Config')
+        config.stubs(:authorization_endpoint).returns('https://example.com/authorization')
+        config.stubs(:token_endpoint).returns('https://example.com/token')
+        config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
+        config.stubs(:jwks_uri).returns('https://example.com/jwks')
+        config.stubs(:end_session_endpoint).returns('https://example.com/logout')
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
+        request.stubs(:query_string).returns('id_token_hint=abcd1234')
 
         strategy.expects(:redirect).with(expected_redirect)
         strategy.other_phase

--- a/test/strategy_test_case.rb
+++ b/test/strategy_test_case.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class StrategyTestCase < MiniTest::Test
+class StrategyTestCase < Minitest::Test
   class DummyApp
     def call(env); end
   end


### PR DESCRIPTION
Encode `id_token_hint` parameter when present in the request query.
    
It is recommended that an `id_token_hint` parameter is supplied in an RP initiated logout request.
OIDC compliant libraries such as [node-oidc-provider](https://github.com/panva/node-oidc-provider/blob/main/lib/actions/end_session.js) will not redirect to the  unless valid `id_token_hint` or `client_id` parameters are present.
    
See: https://openid.net/specs/openid-connect-rpinitiated-1_0.html for recommendation.
