### PR TITLE
feat: Allow calling of the UserInfo endpoint to be configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ end
 | jwt_secret_base64            | For HMAC with SHA2 (e.g. HS256) signing algorithms, specify the base64-encoded secret used to sign the JWT token. Defaults to the OAuth2 client secret if not specified. | no       | client_options.secret         | "bXlzZWNyZXQ=\n"                                    |
 | logout_path                  | The log out is only triggered when the request path ends on this path                                                                                                    | no       | '/logout'                     | '/sign_out'                                         |
 | acr_values                   | Authentication Class Reference(ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)     | no       | nil                           | "c1 c2"                                             |
+| call_userinfo_endpoint       | Whether to call the userinfo endpoint                                                                                                                                    | no       | true                          | one of: true, false                                 |
 
 ### Client Config Options
 

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -67,6 +67,7 @@ module OmniAuth
         },
         code_challenge_method: 'S256',
       }
+      option :call_userinfo_endpoint, true
 
       option :logout_path, '/logout'
 
@@ -258,10 +259,14 @@ module OmniAuth
 
         if access_token.id_token
           decoded = decode_id_token(access_token.id_token).raw_attributes
+          merge_with = JSON::JWS.new({})
+          merge_with = access_token.userinfo!.raw_attributes if options.call_userinfo_endpoint
 
-          @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new access_token.userinfo!.raw_attributes.merge(decoded)
-        else
+          @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new merge_with.merge(decoded)
+        elsif options.call_userinfo_endpoint
           @user_info = access_token.userinfo!
+        else
+          @user_info = ::OpenIDConnect::ResponseObject::UserInfo.new
         end
       end
 


### PR DESCRIPTION
Allows the calling of the UserInfo endpoint to be configurable.

As mentioned in #148, [ADFS does not support the `email` or `profile` claims](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-faq#what-permitted-scopes-are-supported-by-ad-fs-), and calling the UserInfo endpoint is pointless, as [it only returns the subject](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/overview/ad-fs-faq#i-m-trying-to-get-more-claims-on-the-userinfo-endpoint--but-it-s-only-returning-subject--how-can-i-get-more-claims-).

As the UserInfo endpoint [is not required](https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata), this PR adds a new config item - `call_userinfo_endpoint` (default `true`), which allows the skipping of this endpoint.

Resolves #145