### PR TITLE
Destroy session when logging out

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -152,6 +152,7 @@ module OmniAuth
         if logout_path_pattern.match?(current_path)
           options.issuer = issuer if options.issuer.to_s.empty?
           discover!
+          session.destroy
           return redirect(end_session_uri) if end_session_uri
         end
         call_app!


### PR DESCRIPTION
Currently there is a problem that occurs when having multiple tabs opened, and when logging out of one tab, the session does not get destroyed. This results in the other tabs using the old session which might be a security issue. 