### PR TITLE
Add `audience` to the `client_options`

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ These are the configuration options for the client_options hash of the configura
 | scheme                 | The http scheme to use                                          | https      |                        |
 | host                   | The host of the authorization server                            | nil        |                        |
 | port                   | The port for the authorization server                           | 443        |                        |
-| audience               | The intended consumer of the token                              | nil        |                        |
+| audience               | The intended consumer (`aud` field) of the id_token              | nil        |                        |
 | authorization_endpoint | The authorize endpoint on the authorization server              | /authorize | yes                    |
 | token_endpoint         | The token endpoint on the authorization server                  | /token     | yes                    |
 | userinfo_endpoint      | The user info endpoint on the authorization server              | /userinfo  | yes                    |

--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ These are the configuration options for the client_options hash of the configura
 | scheme                 | The http scheme to use                                          | https      |                        |
 | host                   | The host of the authorization server                            | nil        |                        |
 | port                   | The port for the authorization server                           | 443        |                        |
+| audience               | The intended consumer of the token                              | nil        |                        |
 | authorization_endpoint | The authorize endpoint on the authorization server              | /authorize | yes                    |
 | token_endpoint         | The token endpoint on the authorization server                  | /token     | yes                    |
 | userinfo_endpoint      | The user info endpoint on the authorization server              | /userinfo  | yes                    |

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -465,10 +465,14 @@ module OmniAuth
       def verify_id_token!(id_token)
         return unless id_token
 
-        decode_id_token(id_token).verify!(issuer: options.issuer,
-                                          client_id: client_options.identifier,
-                                          audience: client_options.audience,
-                                          nonce: params['nonce'].presence || stored_nonce)
+        verify_kwargs = {
+          issuer: options.issuer,
+          client_id: client_options.identifier,
+          nonce: params['nonce'].presence || stored_nonce,
+        }
+        verify_kwargs.merge!(audience: client_options.audience) if client_options.audience
+
+        decode_id_token(id_token).verify!(**verify_kwargs)
       end
 
       class CallbackError < StandardError

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -28,6 +28,7 @@ module OmniAuth
                               scheme: 'https',
                               host: nil,
                               port: 443,
+                              audience: nil,
                               authorization_endpoint: '/authorize',
                               token_endpoint: '/token',
                               userinfo_endpoint: '/userinfo',
@@ -466,6 +467,7 @@ module OmniAuth
 
         decode_id_token(id_token).verify!(issuer: options.issuer,
                                           client_id: client_options.identifier,
+                                          audience: client_options.audience,
                                           nonce: params['nonce'].presence || stored_nonce)
       end
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -252,10 +252,11 @@ module OmniAuth
         state = SecureRandom.hex(16)
         strategy.options.response_type = 'id_token'
         strategy.options.issuer = 'example.com'
-        strategy.options.client_options.audience = "my_audience"
+        strategy.options.client_options.audience = 'my_audience'
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
-        id_token.expects(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, audience: "my_audience", nonce: nonce).returns(true)
+        id_token.expects(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, audience: 'my_audience',
+                                        nonce: nonce).returns(true)
         id_token.stubs(:raw_attributes, :to_h).returns(payload)
 
         request.stubs(:params).returns('state' => state, 'nounce' => nonce, 'id_token' => id_token)

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -248,6 +248,26 @@ module OmniAuth
         strategy.callback_phase
       end
 
+      def test_callback_phase_with_audience
+        state = SecureRandom.hex(16)
+        strategy.options.response_type = 'id_token'
+        strategy.options.issuer = 'example.com'
+        strategy.options.client_options.audience = "my_audience"
+
+        id_token = stub('OpenIDConnect::ResponseObject::IdToken')
+        id_token.expects(:verify!).with(issuer: strategy.options.issuer, client_id: @identifier, audience: "my_audience", nonce: nonce).returns(true)
+        id_token.stubs(:raw_attributes, :to_h).returns(payload)
+
+        request.stubs(:params).returns('state' => state, 'nounce' => nonce, 'id_token' => id_token)
+        request.stubs(:path).returns('')
+
+        strategy.stubs(:decode_id_token).returns(id_token)
+        strategy.stubs(:stored_state).returns(state)
+
+        strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
+        strategy.callback_phase
+      end
+
       def test_callback_phase_with_id_token_and_param_provided_nonce # rubocop:disable Metrics/AbcSize
         code = SecureRandom.hex(16)
         state = SecureRandom.hex(16)


### PR DESCRIPTION
I've come across an issue where the `identifier` wasn't equal to the `audience` in the token. This resulted in verification errors because currently it will verify the `aud` against the `identifier` if no `audience` is specified.

In this PR, I introduced the `audience` as `client_options` and will pass this along in the `verify!` of the `decoded_id_token` so the openid_connect gem [can handle the expected audience](https://github.com/nov/openid_connect/blob/e1eb8ea962af43752b1aed2c1063a3e24f96c5bc/lib/openid_connect/response_object/id_token.rb#L30-L32)