### PR TITLE
fix: make require_state skip verification of state

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -120,7 +120,7 @@ module OmniAuth
       def callback_phase
         error = params['error_reason'] || params['error']
         error_description = params['error_description'] || params['error_reason']
-        invalid_state = (options.require_state && params['state'].to_s.empty?) || params['state'] != stored_state
+        invalid_state = options.require_state && (params['state'].to_s.empty? || params['state'] != stored_state)
 
         raise CallbackError, error: params['error'], reason: error_description, uri: params['error_uri'] if error
         raise CallbackError, error: :csrf_detected, reason: "Invalid 'state' parameter" if invalid_state


### PR DESCRIPTION
In https://github.com/omniauth/omniauth_openid_connect/pull/127, `require_state` was introduced because according to https://openid.net/specs/openid-connect-core-1_0.html#rfc.section.3.1.2.1, `state` is recommended but not required:

```
state
    RECOMMENDED. Opaque value used to maintain state between the
    request and the callback. Typically, Cross-Site Request Forgery
    (CSRF, XSRF) mitigation is done by cryptographically binding the
    value of this parameter with a browser cookie.
```

During review, the `require_state` parameter was modified to verify `state` as long as `stored_state` was present. However, `stored_state` always holds at least a random value, so when `require_state` were `false` and if an OpenID provider did not relay the `state` value, authentication would halt with a "Invalid 'state' parameter" error.

This commit updates it so that if `require_state` is set to `false`, the `state` parameter is never checked at all.

Closes #174