### PR TITLE
docs: Add missing space before parenthesis

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ end
 | client_options               | A hash of client options detailed in its own section                                                                                                                     | yes      |                               |                                                     |
 | jwt_secret_base64            | For HMAC with SHA2 (e.g. HS256) signing algorithms, specify the base64-encoded secret used to sign the JWT token. Defaults to the OAuth2 client secret if not specified. | no       | client_options.secret         | "bXlzZWNyZXQ=\n"                                    |
 | logout_path                  | The log out is only triggered when the request path ends on this path                                                                                                    | no       | '/logout'                     | '/sign_out'                                         |
-| acr_values                   | Authentication Class Reference(ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)     | no       | nil                           | "c1 c2"                                             |
+| acr_values                   | Authentication Class Reference (ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)     | no       | nil                           | "c1 c2"                                             |
 
 ### Client Config Options
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ end
 | client_options               | A hash of client options detailed in its own section                                                                                                                     | yes      |                               |                                                     |
 | jwt_secret_base64            | For HMAC with SHA2 (e.g. HS256) signing algorithms, specify the base64-encoded secret used to sign the JWT token. Defaults to the OAuth2 client secret if not specified. | no       | client_options.secret         | "bXlzZWNyZXQ=\n"                                    |
 | logout_path                  | The log out is only triggered when the request path ends on this path                                                                                                    | no       | '/logout'                     | '/sign_out'                                         |
-| acr_values                   | Authentication Class Reference (ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)     | no       | nil                           | "c1 c2"                                             |
+| acr_values                   | Authentication Class Reference (ACR) values to be passed to the authorize_uri to enforce a specific level, see [RFC9470](https://www.rfc-editor.org/rfc/rfc9470.html)    | no       | nil                           | "c1 c2"                                             |
 
 ### Client Config Options
 


### PR DESCRIPTION
This is a tiny improvement of the documentation that I identified while reading through the documentation.

@bufferoverflow can you please have a look?