### PR TITLE
Add token request parameters for authorization code flow

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -271,6 +271,12 @@ module OmniAuth
           client_auth_method: options.client_auth_method,
         }
 
+        if configured_response_type == 'code'
+          token_request_params[:grant_type] = :authorization_code
+          token_request_params[:code] = authorization_code
+          token_request_params[:redirect_uri] = redirect_uri
+        end
+
         token_request_params[:code_verifier] = params['code_verifier'] || session.delete('omniauth.pkce.verifier') if options.pkce
 
         @access_token = client.access_token!(token_request_params)


### PR DESCRIPTION
The access token request needs the code if we're using code flow. Some providers require additional parameters such as grant_type and redirect_uri.

To run tests, pin the minitest version per a conflict with mocha, as noted here: https://github.com/freerange/mocha/issues/614
But do not leave pinned as the gem fails to install under some rubies that previously succeeded.

For example:
net-imap-0.5.0 requires ruby version >= 3.1.0, which is incompatible with the current version, ruby 2.6.8p0 (jruby 9.3.7.0)

Also, Set grant type explicitly when response type is code

Setting the grant_type to :authorization_code in extra_token_params results in token requests with multiple grant types separated by commas, with authorization_code appended to the end, which results in invalid grant type error from the provider.