### PR TITLE
Update supported ruby version 3.4

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3"]
+        ruby: ["2.7", "3.0", "3.1", "3.2", "3.3", "3.4"]
     name: Ruby ${{ matrix.ruby }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Supported Ruby Versions
 
-OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2
+OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2, 3.3
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Supported Ruby Versions
 
-OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2, 3.3
+OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2, 3.3, 3.4
 
 ## Usage
 


### PR DESCRIPTION
Update the README.md to include supported ruby version 3.3; updated to 3.4 at @andykimchris's request, but looks like you're still [not testing 3.4](https://github.com/omniauth/omniauth_openid_connect/blob/master/.github/workflows/main.yml).