### PR TITLE
feat: Add extra token request params for authorization code flow

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -282,6 +282,12 @@ module OmniAuth
 
         token_request_params[:code_verifier] = params['code_verifier'] || session.delete('omniauth.pkce.verifier') if options.pkce
 
+        if configured_response_type == 'code'
+          token_request_params[:grant_type] = :authorization_code
+          token_request_params[:code] = authorization_code
+          token_request_params[:redirect_uri] = redirect_uri
+        end
+
         @access_token = client.access_token!(token_request_params)
         verify_id_token!(@access_token.id_token) if configured_response_type == 'code'
 

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -852,10 +852,12 @@ module OmniAuth
 
       def test_option_client_auth_method
         state = SecureRandom.hex(16)
+        code = SecureRandom.hex(16)
 
         opts = strategy.options.client_options
         opts[:host] = 'foobar.com'
         strategy.options.issuer = 'foobar.com'
+        strategy.options.client_options.redirect_uri = 'https://mysite.com/callback'
         strategy.options.client_auth_method = :not_basic
         strategy.options.client_signing_alg = :RS256
         strategy.options.client_jwk_signing_key = jwks.to_json
@@ -867,6 +869,7 @@ module OmniAuth
         }
 
         request.stubs(:path).returns('')
+        request.stubs(:params).returns('code' => code, 'state' => state)
         strategy.call!('rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce })
 
         id_token = stub('OpenIDConnect::ResponseObject::IdToken')
@@ -874,7 +877,14 @@ module OmniAuth
         ::OpenIDConnect::ResponseObject::IdToken.stubs(:decode).returns(id_token)
 
         url = "#{ opts.scheme }://#{ opts.host }:#{ opts.port }#{ opts.token_endpoint }"
-        body = { scope: 'openid', grant_type: 'client_credentials', client_id: @identifier, client_secret: @secret }
+        body = {
+          scope: 'openid',
+          grant_type: 'authorization_code',
+          client_id: @identifier,
+          client_secret: @secret,
+          redirect_uri: 'https://mysite.com/callback',
+          code: code,
+        }
 
         stub_request(:post, url).with(body: body).to_return(
           body: json_response.to_json,


### PR DESCRIPTION
In addition to the [PR](https://github.com/omniauth/omniauth_openid_connect/pull/192) I improved the related test case.

I wrongly thought that the `client_id` needs also to be added, but this is already done in the rack oauth2 client.

With this e.g. the usage of Auth0 would also work out-of-the-box with this gem.