### PR TITLE
Add max_age option to authorization parameters

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -189,6 +189,7 @@ module OmniAuth
           nonce: (new_nonce if options.send_nonce),
           hd: options.hd,
           acr_values: options.acr_values,
+          max_age: options.max_age,
         }
 
         opts[:state] = new_state if options.send_state


### PR DESCRIPTION
The `max_age` option was accepted but not actually included in the authorization request parameters. This change ensures that it is now properly sent during the request.