### PR TITLE
updated the method verify! with verify_payload!

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -310,7 +310,7 @@ module OmniAuth
             public_key
           end
 
-        decoded.verify!(keyset)
+        decoded.verify_payload!(keyset)
         ::OpenIDConnect::ResponseObject::IdToken.new(decoded)
       rescue JSON::JWK::Set::KidNotFound
         # If the JWT has a key ID (kid), then we know that the set of
@@ -478,7 +478,7 @@ module OmniAuth
         }
         verify_kwargs.merge!(audience: client_options.audience) if client_options.audience
 
-        decode_id_token(id_token).verify!(**verify_kwargs)
+        decode_id_token(id_token).verify_payload!(**verify_kwargs)
       end
 
       class CallbackError < StandardError


### PR DESCRIPTION
verify! is to be deprecated and will be removed in the next major version of ruby-jwt

verify_payload! is to be used instead

this is related to [this issue](https://github.com/omniauth/omniauth_openid_connect/issues/203)

> It is clearly mentioned in [this document](https://www.rubydoc.info/gems/jwt/JWT/Claims) that .verify! is deprecated, and verify_payload! is to be used instead