### PR TITLE
Run setup phase before logout

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -157,6 +157,12 @@ module OmniAuth
 
       def other_phase
         if logout_path_pattern.match?(current_path)
+          
+          # Add the strategy and call the setup phase, so we can have a dynamic post_logout_redirect_uri
+          # This mimics what OmniAuth::Strategy does before the request_phase or callback_phase
+          @env['omniauth.strategy'] = self
+          setup_phase
+
           options.issuer = issuer if options.issuer.to_s.empty?
           discover!
           return redirect(end_session_uri) if end_session_uri

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -22,6 +22,7 @@ module OmniAuth
 
       def test_logout_phase_with_discovery
         expected_redirect = %r{^https://example\.com/logout$}
+        strategy.instance_variable_set(:@env, {})
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
 
@@ -46,6 +47,7 @@ module OmniAuth
 
       def test_logout_phase_with_discovery_and_post_logout_redirect_uri
         expected_redirect = 'https://example.com/logout?post_logout_redirect_uri=https%3A%2F%2Fmysite.com'
+        strategy.instance_variable_set(:@env, {})
         strategy.options.client_options.host = 'example.com'
         strategy.options.discovery = true
         strategy.options.post_logout_redirect_uri = 'https://mysite.com'
@@ -69,7 +71,36 @@ module OmniAuth
         strategy.other_phase
       end
 
+      def test_logout_phase_with_discovery_and_dynamic_post_logout_redirect_uri
+        expected_redirect = 'https://example.com/logout?post_logout_redirect_uri=https%3A%2F%2Fmysite.com'
+        strategy.instance_variable_set(:@env, {})
+        strategy.options.client_options.host = 'example.com'
+        strategy.options.discovery = true
+        strategy.options.setup = proc { |env| 
+          env['omniauth.strategy'].options[:post_logout_redirect_uri] = 'https://mysite.com'
+        }
+
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('https://example.com/')
+        ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(issuer)
+
+        config = stub('OpenIDConnect::Discovery::Provder::Config')
+        config.stubs(:authorization_endpoint).returns('https://example.com/authorization')
+        config.stubs(:token_endpoint).returns('https://example.com/token')
+        config.stubs(:userinfo_endpoint).returns('https://example.com/userinfo')
+        config.stubs(:jwks_uri).returns('https://example.com/jwks')
+        config.stubs(:end_session_endpoint).returns('https://example.com/logout')
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('https://example.com/').returns(config)
+
+        request.stubs(:path_info).returns('/auth/openid_connect/logout')
+        request.stubs(:path).returns('/auth/openid_connect/logout')
+
+        strategy.expects(:redirect).with(expected_redirect)
+        strategy.other_phase
+      end
+
       def test_logout_phase_with_logout_path
+        strategy.instance_variable_set(:@env, {})
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
         strategy.options.logout_path = '/sign_out'
@@ -81,6 +112,7 @@ module OmniAuth
       end
 
       def test_logout_phase
+        strategy.instance_variable_set(:@env, {})
         strategy.options.issuer = 'example.com'
         strategy.options.client_options.host = 'example.com'
 


### PR DESCRIPTION
This PR allows a dynamic post logout redirect uri, using the setup from omniauth

## Why
I have an application where the redirect_uri for the logout depends on the request (one strategy is applied for multiple (sub)domains that each have their own keys and their own `redirect_uri` and `post_logout_redirect_uri`).

I naively assumed that the following would work (simplified for clarity)
```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :openid_connect, {
    name: :openid_connect,
     ...
    setup: proc { |env|
      request = Rack::Request.new(env)
   
      env['omniauth.strategy'].options[:client_options].merge!({
        ...
      })
      env['omniauth.strategy'].options[:post_logout_redirect_uri] = "#{request.base_url}/sessions/sign_out"
    }
  }
end
```

However I discovered that the setup phase does not get called on logout.

## Solution
If the request is a logout request, I mimicked the way `OmniAuth::Strategy` runs the setup when the request is a request or callback. I imagine it doesn't make sense for `OmniAuth::Strategy` to do this before `other_phase` since that would mean running the setup before every request in the application. This makes that the config above would work (I also validated this in my actual application using this version)

I also considered changing `post_logout_redirect_uri` to accept a string or a proc. I found it more intuitive that we would re-use the setup, but I'm happy to still switch this around. The initializer for my example would then be:
```ruby
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :openid_connect, {
    name: :openid_connect,
     ...
    post_logout_redirect_uri: proc { |env|
      request = Rack::Request.new(env)
      "#{request.base_url}/sessions/sign_out"
    }
  }
end
```