### PR TITLE
feat: Support for access tokens exchange over mTLS

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -283,6 +283,7 @@ module OmniAuth
         token_request_params[:code_verifier] = params['code_verifier'] || session.delete('omniauth.pkce.verifier') if options.pkce
 
         @access_token = client.access_token!(token_request_params)
+        @access_token = @access_token.to_mtls if options.client_auth_method.match?(/mtls/)
         verify_id_token!(@access_token.id_token) if configured_response_type == 'code'
 
         @access_token


### PR DESCRIPTION
https://github.com/nov/openid_connect/pull/76 introduced support for retrieving userinfo on a mTLS endpoint, but this was not exposed in this gem. This fixes that.

I'm matching on anything containing `mtls` since I need it to work in conjunction with https://github.com/nov/rack-oauth2/pull/102