### PR TITLE
Handle discovery based lookup when using http and nested realms (keycloak style)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or install it yourself as:
 
 ## Supported Ruby Versions
 
-OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2, 3.3, 3.4
+OmniAuth::OpenIDConnect is tested under 2.7, 3.0, 3.1, 3.2, 3.3, 3.4, 4.0
 
 ## Usage
 

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -110,7 +110,8 @@ module OmniAuth
       end
 
       def config
-        @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(options.issuer)
+        configure_discovery_scheme
+        @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(discovery_base_url)
       end
 
       def request_phase
@@ -250,6 +251,63 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider.discover!(resource).issuer
       end
 
+      # When discovery is enabled we need a *stable* base URL.
+      #
+      # If the user provides an issuer without an explicit scheme (e.g. "keycloak:8080/realms/foo"),
+      # passing it to discovery can lead to unintended HTTPS/TLS attempts depending on underlying client defaults.
+      #
+      # Recommended behavior: only trust options.issuer for discovery if it is an absolute URI with http/https scheme.
+      # Otherwise, fall back to client_options.scheme/host/port.
+      def discovery_base_url
+        issuer = options.issuer.to_s
+        if issuer.match?(/\Ahttps?:\/\//)
+          uri = URI.parse(issuer)
+          # If path is empty or just '/', use issuer as-is (it's already a base URL)
+          if uri.path.nil? || uri.path.empty? || uri.path == '/'
+            issuer
+          else
+            # Has a real path beyond '/', extract base URL
+            resource = "#{uri.scheme}://#{uri.host}"
+            default_port = (uri.scheme == 'https') ? 443 : 80
+            resource = "#{resource}:#{uri.port}" if uri.port != default_port
+            resource
+          end
+        else
+          resource = "#{client_options.scheme}://#{client_options.host}"
+          resource = "#{resource}:#{client_options.port}" if client_options.port
+          resource
+        end
+      end
+
+      # Configure the SWD (Simple Web Discovery) library to use the correct URI scheme.
+      #
+      # The SWD library (used by openid_connect gem for discovery) defaults to URI::HTTPS,
+      # which causes SSL connection attempts even when an HTTP URL is explicitly provided.
+      # This results in "SSL_connect" errors when connecting to non-SSL servers (e.g.,
+      # development Keycloak instances running on HTTP).
+      #
+      # This method fixes the issue by setting SWD.url_builder to URI::HTTP or URI::HTTPS
+      # based on the actual scheme of the discovery_base_url, ensuring the gem respects
+      # the explicitly configured protocol.
+      #
+      # See: https://github.com/nov/openid_connect/issues/47
+      def configure_discovery_scheme
+        base_url = discovery_base_url
+        return if base_url.nil? || base_url.empty?
+
+        uri = URI.parse(base_url)
+        
+        # Set SWD.url_builder to use HTTP or HTTPS based on the discovery URL scheme
+        # This prevents the gem from forcing HTTPS when HTTP is explicitly specified
+        if uri.scheme == 'http'
+          require 'swd'
+          SWD.url_builder = URI::HTTP
+        elsif uri.scheme == 'https'
+          require 'swd'
+          SWD.url_builder = URI::HTTPS
+        end
+      end
+
       def discover!
         return unless options.discovery
 
@@ -258,6 +316,9 @@ module OmniAuth
         client_options.userinfo_endpoint = config.userinfo_endpoint
         client_options.jwks_uri = config.jwks_uri
         client_options.end_session_endpoint = config.end_session_endpoint if config.respond_to?(:end_session_endpoint)
+
+        # Keep issuer consistent with what the provider advertises so later token verification uses the correct issuer.
+        options.issuer = config.issuer if config.respond_to?(:issuer) && config.issuer
       end
 
       def user_info

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -114,19 +114,8 @@ module OmniAuth
         @config ||= ::OpenIDConnect::Discovery::Provider::Config.discover!(discovery_base_url)
       end
 
-      def request_phase
-        puts "\nHERE I AM\n"
-        # Debug logging to diagnose issuer issues
-        if defined?(Rails) && Rails.logger
-          puts "[OpenIDConnect] request_phase - options.issuer BEFORE: #{options.issuer.inspect}"
-          puts "[OpenIDConnect] request_phase - options.issuer.to_s.empty?: #{options.issuer.to_s.empty?}"
-        end
-        
+      def request_phase        
         options.issuer = issuer if issuer_empty?
-        
-        if defined?(Rails) && Rails.logger
-          puts "[OpenIDConnect] request_phase - options.issuer AFTER: #{options.issuer.inspect}"
-        end
         
         discover!
         redirect authorize_uri
@@ -285,13 +274,6 @@ module OmniAuth
         issuer_value = issuer_value.call if issuer_value.respond_to?(:call)
         issuer = issuer_value.to_s
         
-        # Debug logging to see what we're working with
-        if defined?(Rails) && Rails.logger
-          puts "[OpenIDConnect] discovery_base_url - options.issuer: #{options.issuer.inspect}"
-          puts "[OpenIDConnect] discovery_base_url - issuer value: #{issuer_value.inspect}"
-          puts "[OpenIDConnect] discovery_base_url - issuer string: #{issuer}"
-        end
-        
         if issuer.match?(/\Ahttps?:\/\//)
           # Use the full issuer URL as-is for discovery
           # The discovery endpoint will be: issuer + '/.well-known/openid-configuration'
@@ -303,9 +285,6 @@ module OmniAuth
           # Issuer doesn't have a scheme, construct URL from client_options
           resource = "#{client_options.scheme}://#{client_options.host}"
           resource = "#{resource}:#{client_options.port}" if client_options.port
-          if defined?(Rails) && Rails.logger
-            puts "[OpenIDConnect] discovery_base_url - constructed from client_options: #{resource}"
-          end
           resource
         end
       end
@@ -341,8 +320,7 @@ module OmniAuth
 
       def discover!
         return unless options.discovery
-        puts "I am in discover"
-        puts config
+
         client_options.authorization_endpoint = config.authorization_endpoint
         client_options.token_endpoint = config.token_endpoint
         client_options.userinfo_endpoint = config.userinfo_endpoint

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -115,16 +115,17 @@ module OmniAuth
       end
 
       def request_phase
+        puts "\nHERE I AM\n"
         # Debug logging to diagnose issuer issues
         if defined?(Rails) && Rails.logger
-          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer BEFORE: #{options.issuer.inspect}"
-          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer.to_s.empty?: #{options.issuer.to_s.empty?}"
+          puts "[OpenIDConnect] request_phase - options.issuer BEFORE: #{options.issuer.inspect}"
+          puts "[OpenIDConnect] request_phase - options.issuer.to_s.empty?: #{options.issuer.to_s.empty?}"
         end
         
-        options.issuer = issuer if options.issuer.to_s.empty?
+        options.issuer = issuer if issuer_empty?
         
         if defined?(Rails) && Rails.logger
-          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer AFTER: #{options.issuer.inspect}"
+          puts "[OpenIDConnect] request_phase - options.issuer AFTER: #{options.issuer.inspect}"
         end
         
         discover!
@@ -146,7 +147,7 @@ module OmniAuth
 
         return unless valid_response_type?
 
-        options.issuer = issuer if options.issuer.nil? || options.issuer.empty?
+        options.issuer = issuer if issuer_empty?
 
         verify_id_token!(params['id_token']) if configured_response_type == 'id_token'
         discover!
@@ -169,7 +170,7 @@ module OmniAuth
 
       def other_phase
         if logout_path_pattern.match?(current_path)
-          options.issuer = issuer if options.issuer.to_s.empty?
+          options.issuer = issuer if issuer_empty?
           discover!
           return redirect(end_session_uri) if end_session_uri
         end
@@ -262,6 +263,15 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider.discover!(resource).issuer
       end
 
+      # Helper method to safely check if issuer is empty, handling Proc/lambda values
+      def issuer_empty?
+        return true if options.issuer.nil?
+        
+        issuer_value = options.issuer
+        issuer_value = issuer_value.call if issuer_value.respond_to?(:call)
+        issuer_value.to_s.empty?
+      end
+
       # When discovery is enabled we need a *stable* base URL.
       #
       # If the user provides an issuer without an explicit scheme (e.g. "keycloak:8080/realms/foo"),
@@ -270,19 +280,23 @@ module OmniAuth
       # Recommended behavior: only trust options.issuer for discovery if it is an absolute URI with http/https scheme.
       # Otherwise, fall back to client_options.scheme/host/port.
       def discovery_base_url
-        issuer = options.issuer.to_s
+        # Handle Proc/lambda for options.issuer (common pattern for runtime evaluation)
+        issuer_value = options.issuer
+        issuer_value = issuer_value.call if issuer_value.respond_to?(:call)
+        issuer = issuer_value.to_s
         
         # Debug logging to see what we're working with
         if defined?(Rails) && Rails.logger
-          Rails.logger.debug "[OpenIDConnect] discovery_base_url - options.issuer: #{options.issuer.inspect}"
-          Rails.logger.debug "[OpenIDConnect] discovery_base_url - issuer string: #{issuer}"
+          puts "[OpenIDConnect] discovery_base_url - options.issuer: #{options.issuer.inspect}"
+          puts "[OpenIDConnect] discovery_base_url - issuer value: #{issuer_value.inspect}"
+          puts "[OpenIDConnect] discovery_base_url - issuer string: #{issuer}"
         end
         
         if issuer.match?(/\Ahttps?:\/\//)
           # Use the full issuer URL as-is for discovery
           # The discovery endpoint will be: issuer + '/.well-known/openid-configuration'
           if defined?(Rails) && Rails.logger
-            Rails.logger.debug "[OpenIDConnect] discovery_base_url - using issuer as-is: #{issuer}"
+            puts "[OpenIDConnect] discovery_base_url - using issuer as-is: #{issuer}"
           end
           issuer
         else
@@ -290,7 +304,7 @@ module OmniAuth
           resource = "#{client_options.scheme}://#{client_options.host}"
           resource = "#{resource}:#{client_options.port}" if client_options.port
           if defined?(Rails) && Rails.logger
-            Rails.logger.debug "[OpenIDConnect] discovery_base_url - constructed from client_options: #{resource}"
+            puts "[OpenIDConnect] discovery_base_url - constructed from client_options: #{resource}"
           end
           resource
         end
@@ -327,7 +341,8 @@ module OmniAuth
 
       def discover!
         return unless options.discovery
-
+        puts "I am in discover"
+        puts config
         client_options.authorization_endpoint = config.authorization_endpoint
         client_options.token_endpoint = config.token_endpoint
         client_options.userinfo_endpoint = config.userinfo_endpoint

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -252,13 +252,9 @@ module OmniAuth
         ::OpenIDConnect::Discovery::Provider.discover!(resource).issuer
       end
 
-      # Helper method to safely check if issuer is empty, handling Proc/lambda values
+      # Helper method to safely check if issuer is empty
       def issuer_empty?
-        return true if options.issuer.nil?
-        
-        issuer_value = options.issuer
-        issuer_value = issuer_value.call if issuer_value.respond_to?(:call)
-        issuer_value.to_s.empty?
+        options.issuer.nil? || options.issuer.to_s.empty?
       end
 
       # When discovery is enabled we need a *stable* base URL.
@@ -269,10 +265,7 @@ module OmniAuth
       # Recommended behavior: only trust options.issuer for discovery if it is an absolute URI with http/https scheme.
       # Otherwise, fall back to client_options.scheme/host/port.
       def discovery_base_url
-        # Handle Proc/lambda for options.issuer (common pattern for runtime evaluation)
-        issuer_value = options.issuer
-        issuer_value = issuer_value.call if issuer_value.respond_to?(:call)
-        issuer = issuer_value.to_s
+        issuer = options.issuer.to_s
         
         if issuer.match?(/\Ahttps?:\/\//)
           # Use the full issuer URL as-is for discovery

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -261,18 +261,11 @@ module OmniAuth
       def discovery_base_url
         issuer = options.issuer.to_s
         if issuer.match?(/\Ahttps?:\/\//)
-          uri = URI.parse(issuer)
-          # If path is empty or just '/', use issuer as-is (it's already a base URL)
-          if uri.path.nil? || uri.path.empty? || uri.path == '/'
-            issuer
-          else
-            # Has a real path beyond '/', extract base URL
-            resource = "#{uri.scheme}://#{uri.host}"
-            default_port = (uri.scheme == 'https') ? 443 : 80
-            resource = "#{resource}:#{uri.port}" if uri.port != default_port
-            resource
-          end
+          # Use the full issuer URL as-is for discovery
+          # The discovery endpoint will be: issuer + '/.well-known/openid-configuration'
+          issuer
         else
+          # Issuer doesn't have a scheme, construct URL from client_options
           resource = "#{client_options.scheme}://#{client_options.host}"
           resource = "#{resource}:#{client_options.port}" if client_options.port
           resource

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -115,7 +115,18 @@ module OmniAuth
       end
 
       def request_phase
+        # Debug logging to diagnose issuer issues
+        if defined?(Rails) && Rails.logger
+          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer BEFORE: #{options.issuer.inspect}"
+          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer.to_s.empty?: #{options.issuer.to_s.empty?}"
+        end
+        
         options.issuer = issuer if options.issuer.to_s.empty?
+        
+        if defined?(Rails) && Rails.logger
+          Rails.logger.debug "[OpenIDConnect] request_phase - options.issuer AFTER: #{options.issuer.inspect}"
+        end
+        
         discover!
         redirect authorize_uri
       end

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -277,9 +277,6 @@ module OmniAuth
         if issuer.match?(/\Ahttps?:\/\//)
           # Use the full issuer URL as-is for discovery
           # The discovery endpoint will be: issuer + '/.well-known/openid-configuration'
-          if defined?(Rails) && Rails.logger
-            puts "[OpenIDConnect] discovery_base_url - using issuer as-is: #{issuer}"
-          end
           issuer
         else
           # Issuer doesn't have a scheme, construct URL from client_options

--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -260,14 +260,27 @@ module OmniAuth
       # Otherwise, fall back to client_options.scheme/host/port.
       def discovery_base_url
         issuer = options.issuer.to_s
+        
+        # Debug logging to see what we're working with
+        if defined?(Rails) && Rails.logger
+          Rails.logger.debug "[OpenIDConnect] discovery_base_url - options.issuer: #{options.issuer.inspect}"
+          Rails.logger.debug "[OpenIDConnect] discovery_base_url - issuer string: #{issuer}"
+        end
+        
         if issuer.match?(/\Ahttps?:\/\//)
           # Use the full issuer URL as-is for discovery
           # The discovery endpoint will be: issuer + '/.well-known/openid-configuration'
+          if defined?(Rails) && Rails.logger
+            Rails.logger.debug "[OpenIDConnect] discovery_base_url - using issuer as-is: #{issuer}"
+          end
           issuer
         else
           # Issuer doesn't have a scheme, construct URL from client_options
           resource = "#{client_options.scheme}://#{client_options.host}"
           resource = "#{resource}:#{client_options.port}" if client_options.port
+          if defined?(Rails) && Rails.logger
+            Rails.logger.debug "[OpenIDConnect] discovery_base_url - constructed from client_options: #{resource}"
+          end
           resource
         end
       end

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -146,7 +146,7 @@ module OmniAuth
         config.stubs(:token_endpoint).returns('http://keycloak:8080/token')
         config.stubs(:userinfo_endpoint).returns('http://keycloak:8080/userinfo')
         config.stubs(:jwks_uri).returns('http://keycloak:8080/jwks')
-        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('http://keycloak:8080').returns(config)
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('http://keycloak:8080/realms/quepid').returns(config)
 
         strategy.expects(:redirect).with(regexp_matches(expected_redirect))
         strategy.request_phase

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -127,6 +127,82 @@ module OmniAuth
         assert_nil strategy.options.client_options.end_session_endpoint
       end
 
+      def test_request_phase_with_discovery_http_scheme_and_port
+        expected_redirect = %r{^http://keycloak:8080/authorize\?client_id=1234&nonce=\w{32}&response_type=code&scope=openid&state=\w{32}$}
+
+        strategy.options.client_options.scheme = 'http'
+        strategy.options.client_options.host = 'keycloak'
+        strategy.options.client_options.port = 8080
+        strategy.options.discovery = true
+
+        # Simulate provider discovery for issuer (used when options.issuer is empty)
+        issuer = stub('OpenIDConnect::Discovery::Issuer')
+        issuer.stubs(:issuer).returns('http://keycloak:8080/realms/quepid')
+        ::OpenIDConnect::Discovery::Provider.stubs(:discover!).with('http://keycloak:8080').returns(issuer)
+
+        config = stub('OpenIDConnect::Discovery::Provider::Config')
+        config.stubs(:issuer).returns('http://keycloak:8080/realms/quepid')
+        config.stubs(:authorization_endpoint).returns('http://keycloak:8080/authorize')
+        config.stubs(:token_endpoint).returns('http://keycloak:8080/token')
+        config.stubs(:userinfo_endpoint).returns('http://keycloak:8080/userinfo')
+        config.stubs(:jwks_uri).returns('http://keycloak:8080/jwks')
+        ::OpenIDConnect::Discovery::Provider::Config.stubs(:discover!).with('http://keycloak:8080').returns(config)
+
+        strategy.expects(:redirect).with(regexp_matches(expected_redirect))
+        strategy.request_phase
+
+        assert_equal 'http://keycloak:8080/realms/quepid', strategy.options.issuer
+        assert_equal 'http://keycloak:8080/authorize', strategy.options.client_options.authorization_endpoint
+      end
+
+      def test_discovery_ignores_scheme_less_issuer_and_falls_back_to_client_options
+        # issuer is present but scheme-less; discovery should not use it as base
+        strategy.options.issuer = 'keycloak:8080/realms/quepid'
+        strategy.options.discovery = true
+        strategy.options.client_options.scheme = 'http'
+        strategy.options.client_options.host = 'keycloak'
+        strategy.options.client_options.port = 8080
+
+        config = stub('OpenIDConnect::Discovery::Provider::Config')
+        config.stubs(:issuer).returns('http://keycloak:8080/realms/quepid')
+        config.stubs(:authorization_endpoint).returns('http://keycloak:8080/authorize')
+        config.stubs(:token_endpoint).returns('http://keycloak:8080/token')
+        config.stubs(:userinfo_endpoint).returns('http://keycloak:8080/userinfo')
+        config.stubs(:jwks_uri).returns('http://keycloak:8080/jwks')
+
+        # key assertion: discover! uses http://keycloak:8080 (from client_options), NOT the scheme-less issuer
+        ::OpenIDConnect::Discovery::Provider::Config.expects(:discover!).with('http://keycloak:8080').returns(config)
+
+        # call the private method via request_phase which triggers discover!
+        ::OpenIDConnect::Discovery::Provider.stubs(:discover!).returns(stub('OpenIDConnect::Discovery::Issuer', issuer: 'http://keycloak:8080/realms/quepid'))
+
+        strategy.expects(:redirect)
+        strategy.request_phase
+
+        assert_equal 'http://keycloak:8080/realms/quepid', strategy.options.issuer
+      end
+
+      def test_configure_discovery_scheme_sets_swd_url_builder_for_http
+        require 'swd'
+        
+        # Test with HTTP scheme
+        strategy.options.issuer = 'http://keycloak:8080/realms/quepid'
+        strategy.options.discovery = true
+        
+        # Call the private method to configure discovery scheme
+        strategy.send(:configure_discovery_scheme)
+        
+        # Verify SWD.url_builder is set to URI::HTTP for HTTP URLs
+        assert_equal URI::HTTP, SWD.url_builder
+        
+        # Test with HTTPS scheme
+        strategy.options.issuer = 'https://example.com/realms/test'
+        strategy.send(:configure_discovery_scheme)
+        
+        # Verify SWD.url_builder is set to URI::HTTPS for HTTPS URLs
+        assert_equal URI::HTTPS, SWD.url_builder
+      end
+
       def test_request_phase_with_response_mode
         expected_redirect = %r{^https://example\.com/authorize\?client_id=1234&nonce=\w{32}&response_mode=form_post&response_type=id_token&scope=openid&state=\w{32}$}
         strategy.options.issuer = 'example.com'


### PR DESCRIPTION
I think I have stumbled across two bugs.  

The first is that if I am using a `http` url with the discovery link, SWD was forcing it to a `https`, regardless of settings.   There is a workaround described in the issue https://github.com/omniauth/omniauth_openid_connect/issues/186, however this PR should fix the bug!

The second is that Keycload used a nested url for the well known url: `http://keycloak:8080/realms/quepid/.well-known/openid-configuration` and it was being converted to `http://keycloak:8080/.well-known/openid-configuration`