### PR TITLE
fix: use standard OIDC callback error parameters

### DIFF
--- a/lib/omniauth/strategies/openid_connect.rb
+++ b/lib/omniauth/strategies/openid_connect.rb
@@ -120,8 +120,8 @@ module OmniAuth
       end
 
       def callback_phase
-        error = params['error_reason'] || params['error']
-        error_description = params['error_description'] || params['error_reason']
+        error = params['error']
+        error_description = params['error_description']
         invalid_state =
           if options.send_state
             (options.require_state && params['state'].to_s.empty?) || params['state'] != stored_state

--- a/test/lib/omniauth/strategies/openid_connect_test.rb
+++ b/test/lib/omniauth/strategies/openid_connect_test.rb
@@ -610,11 +610,26 @@ module OmniAuth
 
       def test_callback_phase_with_error
         state = SecureRandom.hex(16)
-        request.stubs(:params).returns('error' => 'invalid_request')
+        request.stubs(:params).returns(
+          'error' => 'invalid_request',
+          'error_description' => 'Unsupported response_type value',
+          'error_uri' => 'https://example.com/errors/invalid_request'
+        )
         request.stubs(:path).returns('')
 
         strategy.call!({ 'rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce } })
-        strategy.expects(:fail!)
+        strategy.expects(:fail!).with('invalid_request', is_a(OmniAuth::Strategies::OpenIDConnect::CallbackError))
+        strategy.callback_phase
+      end
+
+      def test_callback_phase_with_non_standard_error_reason
+        state = SecureRandom.hex(16)
+        request.stubs(:params).returns('error_reason' => 'invalid_request', 'state' => state)
+        request.stubs(:path).returns('')
+
+        strategy.call!({ 'rack.session' => { 'omniauth.state' => state, 'omniauth.nonce' => nonce } })
+
+        strategy.expects(:fail!).with(:missing_code, is_a(OmniAuth::OpenIDConnect::MissingCodeError))
         strategy.callback_phase
       end
 


### PR DESCRIPTION
## Summary

This is a small cleanup to align callback error handling with the OpenID Connect authorization error response parameters.

It removes handling for the non-standard `error_reason` callback parameter. OpenID Connect defines `error`, `error_description`, `error_uri`, and `state`, but not `error_reason`.

The existing `CallbackError` representation is left unchanged; this only changes which callback request parameters are accepted as an authorization error response.

Spec reference: https://openid.net/specs/openid-connect-core-1_0.html#AuthError

## Verification

- `bundle exec rake test`